### PR TITLE
Changing minor stuff for pytorch1.0 compatibility

### DIFF
--- a/i3d_pt_demo.py
+++ b/i3d_pt_demo.py
@@ -54,7 +54,7 @@ def run_demo(args):
         print('===== Final predictions ====')
         print('logits proba class '.format(args.top_k))
         for i in range(args.top_k):
-            logit_score = out_logit[0, top_idx[0, i]].data[0]
+            logit_score = out_logit[0, top_idx[0, i]].data.item()
             print('{:.6e} {:.6e} {}'.format(logit_score, top_val[0, i],
                                             kinetics_classes[top_idx[0, i]]))
 

--- a/src/i3dpt.py
+++ b/src/i3dpt.py
@@ -356,7 +356,7 @@ def _get_padding(padding_name, conv_shape):
     if padding_name == "VALID":
         return [0, 0]
     elif padding_name == "SAME":
-        #return [math.ceil(int(conv_shape[0])/2), math.ceil(int(conv_shape[1])/2)]
+        # return [math.ceil(int(conv_shape[0])/2), math.ceil(int(conv_shape[1])/2)]
         return [
             math.floor(int(conv_shape[0]) / 2),
             math.floor(int(conv_shape[1]) / 2),
@@ -389,11 +389,12 @@ def load_conv3d(state_dict, name_pt, sess, name_tf, bias=False, bn=True):
 
         out_planes = conv_weights_rs.shape[0]
         state_dict[name_pt + '.batch3d.weight'] = torch.ones(out_planes)
-        state_dict[name_pt + '.batch3d.bias'] = torch.from_numpy(beta)
+        state_dict[name_pt +
+                   '.batch3d.bias'] = torch.from_numpy(beta.squeeze())
         state_dict[name_pt
-                   + '.batch3d.running_mean'] = torch.from_numpy(moving_mean)
+                   + '.batch3d.running_mean'] = torch.from_numpy(moving_mean.squeeze())
         state_dict[name_pt
-                   + '.batch3d.running_var'] = torch.from_numpy(moving_var)
+                   + '.batch3d.running_var'] = torch.from_numpy(moving_var.squeeze())
 
 
 def load_mixed(state_dict, name_pt, sess, name_tf, fix_typo=False):


### PR DESCRIPTION
`variable.data[0]` is deprecated for scalar, changed it to `variable.data.item()`.