### PR TITLE
Arch mod

### DIFF
--- a/src/i3dpt.py
+++ b/src/i3dpt.py
@@ -77,7 +77,6 @@ class Unit3Dpy(torch.nn.Module):
 
         if padding == 'SAME':
             if not simplify_pad:
-                # self.pad = torch.nn.ConstantPad3d(padding_shape, 0)
                 self.pads = [torch.nn.ConstantPad3d(x, 0) for x in padding_shapes]
                 self.conv3d = torch.nn.Conv3d(
                     in_channels,


### PR DESCRIPTION
Thanks for sharing the implementation!  These are just a few small changes to achieve numerical consistency with the TF version by:

1. Modifying the padding algorithm to match Tensorflow "SAME" for `Unit3Dpy` and `MaxPool3dTFPadding`.
2. Updating the batch norm hyperparams.

Tested on PyTorch 0.4.1.  Running the `i3d_pt_demo.py` produces:

```
Top 5 classes and associated probabilities:
[playing cricket]: 9.999968E-01
[playing kickball]: 1.335340E-06
[catching or throwing baseball]: 4.553116E-07
[shooting goal (soccer)]: 3.143419E-07
[catching or throwing softball]: 1.924329E-07
Top 5 classes and associated probabilities:
[playing cricket]: 9.477569E-01
[hurling (sport)]: 4.068211E-02
[playing tennis]: 4.154132E-03
[playing squash or racquetball]: 2.474060E-03
[hitting baseball]: 1.380014E-03
===== Final predictions ====
logits proba class
4.181368e+01 1.000000e+00 playing cricket
2.149398e+01 1.497148e-09 hurling (sport)
2.013410e+01 3.843058e-10 catching or throwing baseball
1.922558e+01 1.549212e-10 catching or throwing softball
1.891534e+01 1.135999e-10 hitting baseball
```